### PR TITLE
Faltaban archivos

### DIFF
--- a/src/conversation/conversation.module.ts
+++ b/src/conversation/conversation.module.ts
@@ -1,15 +1,17 @@
 import { Module } from '@nestjs/common';
 import { ConversationService } from './conversation.service';
 import { ConversationController } from './conversation.controller';
-import { Conversation } from './entities/conversation.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { PassportModule } from '@nestjs/passport';
+import { Conversation } from './entities/conversation.entity';
+import { Message } from 'src/message/entities/message.entity';
 
 @Module({
+	imports: [
+		TypeOrmModule.forFeature([Conversation, Message]),
+	],
 	controllers: [ConversationController],
 	providers: [ConversationService],
-	imports: [TypeOrmModule.forFeature([Conversation]), PassportModule.register({ defaultStrategy: 'jwt' })],
-	exports: [TypeOrmModule, ConversationService]
+	exports: [ConversationService],
 })
 export class ConversationModule { }
 

--- a/src/conversation/conversation.service.ts
+++ b/src/conversation/conversation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { randomUUID } from 'crypto';
 import { CreateConversationDto } from './dto/create-conversation.dto';
 import { UpdateConversationDto } from './dto/update-conversation.dto';
@@ -6,21 +6,26 @@ import { Repository } from 'typeorm';
 import { Conversation } from './entities/conversation.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateUserDto } from 'src/auth/dto/create_user.dto';
+import { Message } from 'src/message/entities/message.entity'; // added
 
 @Injectable()
 export class ConversationService {
 	constructor(
 		@InjectRepository(Conversation)
 		private readonly conversationRepository: Repository<Conversation>,
+
+		@InjectRepository(Message) // added
+		private readonly messageRepository: Repository<Message>,
 	) { }
 
 	create(createConversationDto: CreateConversationDto) {
 		// Defensive: allow missing body to avoid runtime destructuring error
-		const { user, title } = createConversationDto ?? {} as Partial<CreateConversationDto>;
+		const { user, title, type } = createConversationDto ?? {} as Partial<CreateConversationDto>;
 		const sessionToken = randomUUID();
 		const payload: any = {
 			title: title || 'title',
 			session_token: sessionToken,
+			type: type
 		};
 
 		if (user) payload.user = { id: user };
@@ -45,7 +50,27 @@ export class ConversationService {
 		return `This action updates a #${id} conversation`;
 	}
 
-	remove(id: string) {
-		return `This action removes a #${id} conversation`;
+	async remove(id: string) {
+		const convo = await this.conversationRepository.findOne({ where: { id } });
+		if (!convo) {
+			throw new NotFoundException(`Conversation with id ${id} not found`);
+		}
+
+		// eliminar mensajes asociados primero para evitar violación FK
+		try {
+			await this.messageRepository.createQueryBuilder()
+				.delete()
+				.where('"conversationId" = :id', { id })
+				.execute();
+		} catch (err) {
+			// fallback: intentar eliminar por relación si la columna tiene otro nombre
+			console.warn('Warning deleting messages by conversationId, trying relation-based remove', err);
+			await this.messageRepository.delete({ conversation: convo as any });
+		}
+
+		await this.conversationRepository.remove(convo);
+		console.log(`Conversation with id ${id} removed`);
+		return { success: true, id };
 	}
+
 }

--- a/src/conversation/dto/create-conversation.dto.ts
+++ b/src/conversation/dto/create-conversation.dto.ts
@@ -10,4 +10,7 @@ export class CreateConversationDto {
 	@IsString()
 	title?: string;
 
+	@IsEnum(['sales', 'tecnico', 'anonimo'])
+	type: string;
+
 }

--- a/src/conversation/entities/conversation.entity.ts
+++ b/src/conversation/entities/conversation.entity.ts
@@ -30,4 +30,7 @@ export class Conversation {
 	@Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
 	updated_at: Date;
 
+	@Column({ type: 'enum', enum: ['sales', 'tecnico', 'anonimo'], default: 'anonimo' })
+	type: string;
+
 }

--- a/src/webhooks/n8n.controller.ts
+++ b/src/webhooks/n8n.controller.ts
@@ -20,10 +20,8 @@ export class N8nWebhooksController {
 			sender: (sender ?? 'bot') as 'user' | 'bot',
 		});
 
-		console.log({ first: saved });
-
 		// Emit to conversation room
-		this.socketEmitter.emitToConversation(conversationId, 'message', saved);
+		//this.socketEmitter.emitToConversation(conversationId, 'message', saved);
 
 		// Also emit directly to socketId if provided
 		if (socketId) this.socketEmitter.emitToSocket(socketId, 'message', saved);


### PR DESCRIPTION
This pull request introduces support for conversation types and improves the deletion logic for conversations. The main changes include adding a `type` field to conversations, updating the DTO and entity accordingly, and ensuring associated messages are properly deleted when a conversation is removed. There are also some adjustments to module imports and event emission logic.

**Conversation type support:**

* Added a `type` field (enum: `'sales'`, `'tecnico'`, `'anonimo'`) to the `Conversation` entity and `CreateConversationDto`, with appropriate validation and default value. [[1]](diffhunk://#diff-d85fd06739c11e1ff21ad94cc271e344e7ccdf83bbc15c675fe2caebe5663d8fR33-R35) [[2]](diffhunk://#diff-7fa4a1e906804751c6c4dc203d70f1eeff6b11db6bf3ac1fffeecacf0cc66ac9R13-R15)
* Updated the conversation creation logic to handle the new `type` field.

**Conversation deletion improvements:**

* Enhanced the `remove` method in `ConversationService` to first delete all messages associated with a conversation before deleting the conversation itself, handling possible foreign key constraints and providing error handling.

**Module and import adjustments:**

* Updated `ConversationModule` to import the `Message` entity and simplified its exports and imports.

**Webhooks and event emission:**

* Commented out the socket emission to the conversation room in `N8nWebhooksController`, possibly to avoid duplicate or unnecessary events.